### PR TITLE
Debian check updated to include Linuxmint as reported by Ansible 2+ o…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - include: compat.yml
 
 - include: Debian.yml
-  when: ansible_os_family == 'Debian'
+  when: ansible_os_family in [ 'Debian', 'Linuxmint' ]
 
 - include: RedHat.yml
   when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
Ansible reports "ansible_os_family" on Linux Mint as "Linuxmint". I can't find the issue number anymore but last I saw this was to be fixed at a later date which means those of us on Mint need to make these adjustments.
