### PR TITLE
Disable Fedora 21--23, enable Fedora 26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 script:
 - >
   wget -O- bit.ly/ansibletest | env
-  DOCKER_IMAGES="ubuntu:14.04 ubuntu:16.04 fedora:21 fedora:25
+  DOCKER_IMAGES="ubuntu:14.04 ubuntu:16.04 fedora:24 fedora:26
   debian:8"
   ANSIBLE_VERSIONS="1.4 1.8.4 2.1.0.0" sh
 after_failure:

--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,6 @@ test:
       # https://fedorahosted.org/spin-kickstarts/ticket/55
       - >
         wget -qO- bit.ly/ansibletest | env
-        DOCKER_IMAGES="ubuntu:14.04 ubuntu:16.04 fedora:21 fedora:25 debian:8"
+        DOCKER_IMAGES="ubuntu:14.04 ubuntu:16.04 fedora:24 fedora:25 debian:8"
         ANSIBLE_VERSIONS="1.4 1.6.1 1.8.4 2.1.0.0 2.2.1.0"
         sh

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,12 +18,9 @@ galaxy_info:
     - xenial
   - name: Fedora
     versions:
-    - 20
-    - 21
-    - 22
-    - 23
     - 24
     - 25
+    - 26
   categories:
   - desktop
   - networking


### PR DESCRIPTION
These stopped working recently:

* `docker run -i -t fedora:23 sh -c "rpm --import https://dl.google.com/linux/linux_signing_key.pub && dnf upgrade && dnf install https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm"`
* `docker run -i -t fedora:22 sh -c "rpm --import https://dl.google.com/linux/linux_signing_key.pub && yum upgrade && yum install https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm"`
* `docker run -i -t fedora:21 sh -c "rpm --import https://dl.google.com/linux/linux_signing_key.pub && yum upgrade && yum install https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm"`

* Passing: https://travis-ci.org/wtanaka/ansible-role-chrome/builds/271584877
* Failing: https://travis-ci.org/wtanaka/ansible-role-chrome/builds/274072603

This commit drops support for Fedora 21--23 and adds support for Fedora 26